### PR TITLE
Add support for indenting tagged bindings

### DIFF
--- a/align-cljlet.el
+++ b/align-cljlet.el
@@ -46,6 +46,7 @@
 ;; 23-Jan-2011 - Bug fixes and code cleanup.
 ;; 02-Apr-2012 - Package up for Marmalade
 ;; 30-Aug-2012 - Support for aligning defroute.
+;; 04-Nov-2015 - Support for metadata when calculating widths
 ;;
 ;;; Known limitations:
 ;;
@@ -122,12 +123,23 @@
         ))
   t)
 
+(defun acl-forward-sexp ()
+  (condition-case nil
+      (progn
+        (while (or (looking-at "\\^")
+                   (looking-at "\\s-"))
+          (if (looking-at "\\s-")
+              (forward-char)
+            (forward-sexp)))
+        (forward-sexp))
+    (error nil)))
+
 (defun acl-goto-next-pair ()
   "Skip ahead to the next definition"
   (condition-case nil
       (progn
-        (forward-sexp)
-        (forward-sexp)
+        (acl-forward-sexp)
+        (acl-forward-sexp)
         (forward-sexp)
         (backward-sexp)
         t)
@@ -137,7 +149,7 @@
   "Get the width of the current definition"
   (save-excursion
     (let ((col (current-column)))
-      (forward-sexp)
+      (acl-forward-sexp)
       (- (current-column) col))))
 
 (defun acl-has-next-sexp ()
@@ -145,7 +157,7 @@
   (save-excursion
     (condition-case nil
         (progn
-          (forward-sexp)
+          (acl-forward-sexp)
           't)
       ('error nil))))
 
@@ -154,7 +166,8 @@
 
   (condition-case nil
       (progn
-        (forward-sexp 2)
+        (acl-forward-sexp)
+        (acl-forward-sexp)
         (backward-sexp)
         't)
     ('error nil)))
@@ -185,7 +198,8 @@
   (save-excursion
     (condition-case nil
         (progn
-          (forward-sexp 2)
+          (acl-forward-sexp)
+          (acl-forward-sexp)
           t)
       (error nil))))
 


### PR DESCRIPTION
This patch implements and uses an alternate forward-sexp fn which will
skip over ^ prefixed forms considered metadata by the Clojure
reader. This allows align-cljlet to correctly indent forms such as

    (let [^Long x 3
          y 3]
      (+ x y))

to

    (let [^Long x 3
          y       3]
      (+ x y))

since the symbol `Long` is seen to be metadata on whatever the following
sexp is, and consequently the width of the binding is the sum of the
widths of the binding form and all its leading metadata modifiers.

As this same forward-sexp is used for binding value forms, metadata
there will also be ignored and so forms such as

    (let [x ^StringBuilder (make-stringbuilder)
          y 3]
      y)

will be understood to be correctly indented rather than thought to have
multiple pairs on a line and be invalid.