### PR TITLE
Support for as a binding form

### DIFF
--- a/align-cljlet.el
+++ b/align-cljlet.el
@@ -46,6 +46,7 @@
 ;; 23-Jan-2011 - Bug fixes and code cleanup.
 ;; 02-Apr-2012 - Package up for Marmalade
 ;; 30-Aug-2012 - Support for aligning defroute.
+;; 04-Nov-2015 - Support for aligning for
 ;;
 ;;; Known limitations:
 ;;
@@ -91,6 +92,7 @@
             (setq name (buffer-substring-no-properties start (point)))
             (or
              (string-match " *let" name)
+             (string-match " *for" name)
              (string-match " *when-let" name)
              (string-match " *if-let" name)
              (string-match " *binding" name)


### PR DESCRIPTION
This isn't perfect since it misses out on `:let` vectors, but it beats
having no support at all for `for`.