### PR TITLE
Reader macro support

### DIFF
--- a/align-cljlet-test.el
+++ b/align-cljlet-test.el
@@ -50,6 +50,20 @@
   (acl-should-error
    " {:a 1 :b 2}"))
 
+(ert-deftest align-hash-with-reader-macro ()
+  (acl-should-align
+   "
+      {#foo/bar [1 2 3] 234
+       :foobar (list 1 2 3)
+}"
+   "
+{#foo/bar [1 2 3] 234
+ :foobar          (list 1 2 3)
+}")
+
+  (acl-should-error
+   " {:a 1 :b 2}"))
+
 (ert-deftest align-cond ()
   (acl-should-align
    "(cond

--- a/align-cljlet.el
+++ b/align-cljlet.el
@@ -126,13 +126,7 @@
   t)
 
 (defun acl-forward-sexp ()
-  (progn
-    (while (or (looking-at "\\^")
-               (looking-at "\\s-"))
-      (if (looking-at "\\s-")
-          (forward-char)
-        (forward-sexp)))
-    (forward-sexp)))
+  (call-interactively 'clojure-forward-logical-sexp))
 
 (defun acl-goto-next-pair ()
   "Skip ahead to the next definition"

--- a/align-cljlet.el
+++ b/align-cljlet.el
@@ -3,7 +3,7 @@
 ;; Copyrigth (C) 2011  Glen Stampoultzis
 
 ;; Authors: Glen Stampoultzis <gstamp(at)gmail.com>, Reid D McKenzie <https://github.com/arrdem>
-;; Version: 0.4
+;; Version: 0.5
 ;; Package-Requires: ((clojure-mode "1.11.5"))
 ;; Keywords; clojure, align, let
 ;; URL: https://github.com/gstamp/align-cljlet
@@ -48,6 +48,7 @@
 ;; 30-Aug-2012 - Support for aligning defroute.
 ;; 04-Nov-2015 - Support for metadata when calculating widths
 ;; 04-Nov-2015 - Support for aligning for
+;; 01-Jan-2016 - Support for reader macros
 ;;
 ;;; Known limitations:
 ;;


### PR DESCRIPTION
Switches to using the forward function in `clojure-mode`. In doing so we get free support for [tagged literals](http://clojure.org/reader#The%20Reader--Tagged%20Literals).

Fixes: https://github.com/gstamp/align-cljlet/issues/7